### PR TITLE
UF-11088: Implemented service layer for adminstration of sort order

### DIFF
--- a/src/integration-test/java/apptest/CustomSortorderIT.java
+++ b/src/integration-test/java/apptest/CustomSortorderIT.java
@@ -1,0 +1,109 @@
+package apptest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.PUT;
+import static org.springframework.http.HttpStatus.ACCEPTED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.jdbc.Sql;
+
+import se.sundsvall.checklist.Application;
+import se.sundsvall.checklist.integration.db.model.SortorderEntity;
+import se.sundsvall.checklist.integration.db.model.enums.ComponentType;
+import se.sundsvall.checklist.integration.db.repository.SortorderRepository;
+import se.sundsvall.dept44.test.AbstractAppTest;
+import se.sundsvall.dept44.test.annotation.wiremock.WireMockAppTestSuite;
+
+@WireMockAppTestSuite(files = "classpath:/CustomSortorderIT/", classes = Application.class)
+@Sql({
+	"/db/scripts/truncate.sql",
+	"/db/scripts/customSortorderIT-testdata.sql"
+})
+class CustomSortorderIT extends AbstractAppTest {
+	private static final String REQUEST_FILE = "request.json";
+
+	@Autowired
+	private SortorderRepository repository;
+
+	@Test
+	void test01_saveCustomSortorder() {
+		final var organizationNumber = 13;
+
+		assertThat(repository.findAllByMunicipalityIdAndOrganizationNumber("2281", organizationNumber)).hasSize(4).satisfiesExactlyInAnyOrder(
+			entity -> assertEntity(entity, "1455a5d4-1db8-4a25-a49f-92fdd0c60a14", ComponentType.PHASE, 1),
+			entity -> assertEntity(entity, "2455a5d4-1db8-4a25-a49f-92fdd0c60a14", ComponentType.PHASE, 2),
+			entity -> assertEntity(entity, "aba82aca-f841-4257-baec-d745e3ab78bf", ComponentType.TASK, 1),
+			entity -> assertEntity(entity, "bba82aca-f841-4257-baec-d745e3ab78bf", ComponentType.TASK, 2));
+
+		setupCall()
+			.withServicePath("/2281/sortorder/%s".formatted(organizationNumber))
+			.withHttpMethod(PUT)
+			.withRequest(REQUEST_FILE)
+			.withExpectedResponseStatus(ACCEPTED)
+			.withExpectedResponseBodyIsNull()
+			.sendRequestAndVerifyResponse();
+
+		assertThat(repository.findAllByMunicipalityIdAndOrganizationNumber("2281", organizationNumber)).hasSize(4).satisfiesExactlyInAnyOrder(
+			entity -> assertEntity(entity, "1455a5d4-1db8-4a25-a49f-92fdd0c60a14", ComponentType.PHASE, 2),
+			entity -> assertEntity(entity, "2455a5d4-1db8-4a25-a49f-92fdd0c60a14", ComponentType.PHASE, 1),
+			entity -> assertEntity(entity, "aba82aca-f841-4257-baec-d745e3ab78bf", ComponentType.TASK, 2),
+			entity -> assertEntity(entity, "bba82aca-f841-4257-baec-d745e3ab78bf", ComponentType.TASK, 1));
+	}
+
+	private void assertEntity(SortorderEntity entity, String componentId, ComponentType componentType, int position) {
+		assertThat(entity.getComponentId()).isEqualTo(componentId);
+		assertThat(entity.getComponentType()).isEqualTo(componentType);
+		assertThat(entity.getPosition()).isEqualTo(position);
+
+	}
+
+	@Test
+	@DirtiesContext
+	void test02_deleteTask() {
+		assertThat(repository.findAllByComponentId("aba82aca-f841-4257-baec-d745e3ab78bf")).hasSize(2);
+
+		setupCall()
+			.withServicePath("/2281/checklists/15764278-50c8-4a19-af00-077bfc314fd2/phases/1455a5d4-1db8-4a25-a49f-92fdd0c60a14/tasks/aba82aca-f841-4257-baec-d745e3ab78bf")
+			.withHttpMethod(DELETE)
+			.withExpectedResponseStatus(NO_CONTENT)
+			.withExpectedResponseBodyIsNull()
+			.sendRequestAndVerifyResponse();
+
+		assertThat(repository.findAllByComponentId("aba82aca-f841-4257-baec-d745e3ab78bf")).isEmpty();
+	}
+
+	@Test
+	@DirtiesContext
+	void test03_deletePhase() {
+		assertThat(repository.findAllByComponentId("2455a5d4-1db8-4a25-a49f-92fdd0c60a14")).hasSize(2);
+
+		setupCall()
+			.withServicePath("/2281/phases/2455a5d4-1db8-4a25-a49f-92fdd0c60a14")
+			.withHttpMethod(DELETE)
+			.withExpectedResponseStatus(NO_CONTENT)
+			.withExpectedResponseBodyIsNull()
+			.sendRequestAndVerifyResponse();
+
+		assertThat(repository.findAllByComponentId("2455a5d4-1db8-4a25-a49f-92fdd0c60a14")).isEmpty();
+	}
+
+	@Test
+	void test04_deleteOrganization() {
+		final var organizationNumber = 578;
+
+		assertThat(repository.findAllByMunicipalityIdAndOrganizationNumber("2281", organizationNumber)).hasSize(4);
+
+		setupCall()
+			.withServicePath("/2281/organizations/047c78a2-aadc-40e5-8913-8623b1fecc35")
+			.withHttpMethod(DELETE)
+			.withExpectedResponseStatus(NO_CONTENT)
+			.withExpectedResponseBodyIsNull()
+			.sendRequestAndVerifyResponse();
+
+		assertThat(repository.findAllByMunicipalityIdAndOrganizationNumber("2281", organizationNumber)).isEmpty();
+	}
+}

--- a/src/integration-test/resources/CustomSortorderIT/__files/test01_saveCustomSortorder/request.json
+++ b/src/integration-test/resources/CustomSortorderIT/__files/test01_saveCustomSortorder/request.json
@@ -1,0 +1,20 @@
+{"phaseOrder": [
+	{
+		"id": "1455a5d4-1db8-4a25-a49f-92fdd0c60a14",
+		"position": 2,
+		"taskOrder": [
+			{
+				"id": "aba82aca-f841-4257-baec-d745e3ab78bf",
+				"position": 2
+			},
+			{
+				"id": "bba82aca-f841-4257-baec-d745e3ab78bf",
+				"position": 1
+			}
+		]
+	},
+	{
+		"id": "2455a5d4-1db8-4a25-a49f-92fdd0c60a14",
+		"position": 1
+	}
+]}

--- a/src/main/java/se/sundsvall/checklist/api/CustomSortResource.java
+++ b/src/main/java/se/sundsvall/checklist/api/CustomSortResource.java
@@ -25,6 +25,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import se.sundsvall.checklist.api.model.SortorderRequest;
+import se.sundsvall.checklist.service.SortorderService;
 import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
 
 @RestController
@@ -38,8 +39,11 @@ import se.sundsvall.dept44.common.validators.annotation.ValidMunicipalityId;
 })
 @Validated
 class CustomSortResource {
+	private final SortorderService sortorderService;
 
-	CustomSortResource() {}
+	CustomSortResource(SortorderService sortorderService) {
+		this.sortorderService = sortorderService;
+	}
 
 	@Operation(summary = "Creates or replaces a custom sort order of checklist components for the provided organisation number")
 	@ApiResponse(responseCode = "202", description = "Successful Operation", useReturnTypeSchema = true)
@@ -49,6 +53,7 @@ class CustomSortResource {
 		@Parameter(name = "organizationNumber", description = "Organization number to the organization owning the sort order", example = "587") @PathVariable final Integer organizationNumber,
 		@Valid @RequestBody final SortorderRequest request) {
 
+		sortorderService.saveSortorder(municipalityId, organizationNumber, request);
 		return accepted().header(CONTENT_TYPE, ALL_VALUE).build();
 	}
 }

--- a/src/main/java/se/sundsvall/checklist/api/OrganizationResource.java
+++ b/src/main/java/se/sundsvall/checklist/api/OrganizationResource.java
@@ -65,7 +65,7 @@ class OrganizationResource {
 	@GetMapping(produces = APPLICATION_JSON_VALUE)
 	ResponseEntity<List<Organization>> fetchOrganizations(
 		@Parameter(name = "municipalityId", description = "Municipality id", example = "2281") @PathVariable @ValidMunicipalityId final String municipalityId,
-		@Parameter(name = "organizationFilter", description = "Filter response to only include organizations matching provided organization ids", example = "5432") @RequestParam(required = false) List<Integer> organizationFilter) {
+		@Parameter(name = "organizationFilter", description = "Filter response to only include organizations matching provided organization ids") @RequestParam(required = false) List<Integer> organizationFilter) {
 		return ok(organizationService.fetchAllOrganizations(municipalityId, organizationFilter));
 	}
 

--- a/src/main/java/se/sundsvall/checklist/integration/db/repository/SortorderRepository.java
+++ b/src/main/java/se/sundsvall/checklist/integration/db/repository/SortorderRepository.java
@@ -9,12 +9,7 @@ import se.sundsvall.checklist.integration.db.model.SortorderEntity;
 
 @CircuitBreaker(name = "sortorderRepository")
 public interface SortorderRepository extends JpaRepository<SortorderEntity, String> {
-
-	boolean existsByMunicipalityIdAndOrganizationNumber(final String municipalityId, final int organizationNumber);
-
 	List<SortorderEntity> findAllByMunicipalityIdAndOrganizationNumber(final String municipalityId, final int organizationNumber);
 
-	void deleteAllByMunicipalityIdAndOrganizationNumber(final String municipalityId, final int organizationNumber);
-
-	void deleteByMunicipalityIdAndOrganizationNumberAndComponentId(final String municipalityId, final int organizationNumber, final String componentId);
+	List<SortorderEntity> findAllByComponentId(final String componentId);
 }

--- a/src/main/java/se/sundsvall/checklist/service/SortorderService.java
+++ b/src/main/java/se/sundsvall/checklist/service/SortorderService.java
@@ -1,0 +1,25 @@
+package se.sundsvall.checklist.service;
+
+import static se.sundsvall.checklist.service.mapper.SortorderMapper.toSortorderEntities;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import se.sundsvall.checklist.api.model.SortorderRequest;
+import se.sundsvall.checklist.integration.db.repository.SortorderRepository;
+
+@Service
+public class SortorderService {
+
+	private final SortorderRepository sortorderRepository;
+
+	public SortorderService(final SortorderRepository sortorderRepository) {
+		this.sortorderRepository = sortorderRepository;
+	}
+
+	@Transactional
+	public void saveSortorder(final String municipalityId, final Integer organizationNumber, final SortorderRequest request) {
+		sortorderRepository.deleteAllInBatch(sortorderRepository.findAllByMunicipalityIdAndOrganizationNumber(municipalityId, organizationNumber));
+		sortorderRepository.saveAll(toSortorderEntities(municipalityId, organizationNumber, request));
+	}
+}

--- a/src/main/java/se/sundsvall/checklist/service/mapper/SortorderMapper.java
+++ b/src/main/java/se/sundsvall/checklist/service/mapper/SortorderMapper.java
@@ -1,0 +1,65 @@
+package se.sundsvall.checklist.service.mapper;
+
+import static java.util.Collections.emptyList;
+import static java.util.Optional.ofNullable;
+import static java.util.stream.Collectors.toCollection;
+import static org.apache.commons.lang3.ObjectUtils.anyNull;
+import static se.sundsvall.checklist.integration.db.model.enums.ComponentType.PHASE;
+import static se.sundsvall.checklist.integration.db.model.enums.ComponentType.TASK;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import se.sundsvall.checklist.api.model.SortorderRequest;
+import se.sundsvall.checklist.api.model.SortorderRequest.PhaseItem;
+import se.sundsvall.checklist.api.model.SortorderRequest.TaskItem;
+import se.sundsvall.checklist.integration.db.model.SortorderEntity;
+
+public class SortorderMapper {
+
+	private SortorderMapper() {}
+
+	public static List<SortorderEntity> toSortorderEntities(final String municipalityId, final Integer organizationNumber, final SortorderRequest request) {
+		if (anyNull(municipalityId, organizationNumber, request)) {
+			return null;
+		}
+
+		// Start by converting all phases to to entities
+		final var entities = ofNullable(request.getPhaseOrder()).orElse(emptyList()).stream()
+			.map(item -> toSortorderEntity(municipalityId, organizationNumber, item))
+			.collect(toCollection(ArrayList::new));
+
+		// Then convert all tasks to to entities
+		entities.addAll(
+			ofNullable(request.getPhaseOrder()).orElse(emptyList()).stream()
+				.map(PhaseItem::getTaskOrder)
+				.filter(Objects::nonNull)
+				.flatMap(List::stream)
+				.map(item -> toSortorderEntity(municipalityId, organizationNumber, item))
+				.toList());
+
+		return entities;
+	}
+
+	private static SortorderEntity toSortorderEntity(final String municipalityId, final int organizationNumber, final PhaseItem item) {
+		return SortorderEntity.builder()
+			.withComponentId(item.getId())
+			.withComponentType(PHASE)
+			.withMunicipalityId(municipalityId)
+			.withOrganizationNumber(organizationNumber)
+			.withPosition(item.getPosition())
+			.build();
+	}
+
+	private static SortorderEntity toSortorderEntity(final String municipalityId, final int organizationNumber, final TaskItem item) {
+		return SortorderEntity.builder()
+			.withComponentId(item.getId())
+			.withComponentType(TASK)
+			.withMunicipalityId(municipalityId)
+			.withOrganizationNumber(organizationNumber)
+			.withPosition(item.getPosition())
+			.build();
+	}
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -14,6 +14,11 @@ spring:
     hibernate:
       ddl-auto: ${config.jpa.hibernate.ddl-auto}
     defer-datasource-initialization: ${config.jpa.defer-datasource-initialization}
+    properties:
+      hibernate:
+        jdbc:
+          batch_size: 10
+          order_inserts: true  
   sql:
     init:
       mode: ${config.sql.init.mode}

--- a/src/test/java/se/sundsvall/checklist/api/CustomSortResourceFailureTest.java
+++ b/src/test/java/se/sundsvall/checklist/api/CustomSortResourceFailureTest.java
@@ -2,6 +2,7 @@ package se.sundsvall.checklist.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.zalando.problem.Status.BAD_REQUEST;
@@ -13,6 +14,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.zalando.problem.Problem;
@@ -20,10 +22,14 @@ import org.zalando.problem.violations.ConstraintViolationProblem;
 import org.zalando.problem.violations.Violation;
 
 import se.sundsvall.checklist.Application;
+import se.sundsvall.checklist.service.SortorderService;
 
 @SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
 @ActiveProfiles("junit")
 class CustomSortResourceFailureTest {
+
+	@MockBean
+	private SortorderService serviceMock;
 
 	@Autowired
 	private WebTestClient webTestClient;
@@ -151,6 +157,6 @@ class CustomSortResourceFailureTest {
 
 	@AfterEach
 	void verifyNoInteraction() {
-		// TODO when service layer is developed: Add -> verifyNoInteractions(mockSortorderService);
+		verifyNoInteractions(serviceMock);
 	}
 }

--- a/src/test/java/se/sundsvall/checklist/api/CustomSortResourceTest.java
+++ b/src/test/java/se/sundsvall/checklist/api/CustomSortResourceTest.java
@@ -1,5 +1,7 @@
 package se.sundsvall.checklist.api;
 
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 import static se.sundsvall.checklist.TestObjectFactory.generateSortorderRequest;
 
@@ -8,10 +10,12 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import se.sundsvall.checklist.Application;
+import se.sundsvall.checklist.service.SortorderService;
 
 @SpringBootTest(classes = Application.class, webEnvironment = RANDOM_PORT)
 @ActiveProfiles("junit")
@@ -21,22 +25,27 @@ class CustomSortResourceTest {
 	private static final String ORGANIZATION_NUMBER = "123";
 	private static final String BASE_PATH = "/{municipalityId}/sortorder/{organizationNumber}";
 
+	@MockBean
+	private SortorderService serviceMock;
+
 	@Autowired
 	private WebTestClient webTestClient;
 
 	@Test
 	void saveSortorderWithFullRequest() {
+		// Arrange
+		final var request = generateSortorderRequest();
 		// Act
 		webTestClient.put()
 			.uri(builder -> builder.path(BASE_PATH).build(Map.of("municipalityId", MUNICIPALITY_ID, "organizationNumber", ORGANIZATION_NUMBER)))
-			.bodyValue(generateSortorderRequest())
+			.bodyValue(request)
 			.exchange()
 			.expectStatus().isAccepted()
 			.expectBody().isEmpty();
 
 		// Assert and verify
-		// TODO when service layer is present: Add -> verify(sortOrderServiceMock)...
-		// TODO: Remove comment when service layer is present: verifyNoMoreInteractions(sortOrderServiceMock);
+		verify(serviceMock).saveSortorder(MUNICIPALITY_ID, 123, request);
+		verifyNoMoreInteractions(serviceMock);
 	}
 
 	@Test
@@ -54,7 +63,7 @@ class CustomSortResourceTest {
 			.expectBody().isEmpty();
 
 		// Assert and verify
-		// TODO when service layer is present: Add -> verify(sortOrderServiceMock)...
-		// TODO: Remove comment when service layer is present: verifyNoMoreInteractions(sortOrderServiceMock);
+		verify(serviceMock).saveSortorder(MUNICIPALITY_ID, 123, request);
+		verifyNoMoreInteractions(serviceMock);
 	}
 }

--- a/src/test/java/se/sundsvall/checklist/integration/db/repository/SortorderRepositoryTest.java
+++ b/src/test/java/se/sundsvall/checklist/integration/db/repository/SortorderRepositoryTest.java
@@ -78,34 +78,22 @@ class SortorderRepositoryTest {
 	}
 
 	@Test
-	void existsByMunicipalityIdAndOrganizationNumber() {
-		// Act and assert
-		assertThat(repository.existsByMunicipalityIdAndOrganizationNumber("2281", 578)).isTrue();
-		assertThat(repository.existsByMunicipalityIdAndOrganizationNumber("2281", 579)).isFalse();
-		assertThat(repository.existsByMunicipalityIdAndOrganizationNumber("2282", 578)).isFalse();
+	void findAllByComponentId() {
+		// Act
+		final var result = repository.findAllByComponentId("7121d85d-6eee-49b4-8f1d-db1e165a5c29");
+
+		// Assert
+		assertThat(result).hasSize(3);
+		assertThat(result.stream())
+			.extracting(SortorderEntity::getId)
+			.containsExactlyInAnyOrder(
+				"06ca2228-c49e-4e36-91c6-8e3bcb733c14",
+				"14ca2228-c49e-4e36-91c6-8e3bcb733c14",
+				"13ca2228-c49e-4e36-91c6-8e3bcb733c14");
 	}
 
 	@Test
-	void deleteAllByMunicipalityIdAndOrganizationNumber() {
-		// Assert posts exist
-		assertThat(repository.findAllByMunicipalityIdAndOrganizationNumber("2281", 13)).hasSize(6);
-
-		// Act
-		repository.deleteAllByMunicipalityIdAndOrganizationNumber("2281", 13);
-
-		// Assert
-		assertThat(repository.findAllByMunicipalityIdAndOrganizationNumber("2281", 13)).isEmpty();
-	}
-
-	@Test
-	void delete() {
-		// Assert post exist
-		assertThat(repository.findAllByMunicipalityIdAndOrganizationNumber("2281", 14)).hasSize(1);
-
-		// Act
-		repository.deleteByMunicipalityIdAndOrganizationNumberAndComponentId("2281", 14, "7121d85d-6eee-49b4-8f1d-db1e165a5c29");
-
-		// Assert
-		assertThat(repository.findAllByMunicipalityIdAndOrganizationNumber("2281", 14)).isEmpty();
+	void findAllByComponentIdNoMatch() {
+		assertThat(repository.findAllByComponentId("06ca2228-c49e-4e36-91c6-8e3bcb733c14")).isEmpty();
 	}
 }

--- a/src/test/java/se/sundsvall/checklist/service/OrganizationServiceTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/OrganizationServiceTest.java
@@ -27,7 +27,9 @@ import org.zalando.problem.Problem;
 
 import se.sundsvall.checklist.api.model.Organization;
 import se.sundsvall.checklist.integration.db.ChecklistBuilder;
+import se.sundsvall.checklist.integration.db.model.SortorderEntity;
 import se.sundsvall.checklist.integration.db.repository.OrganizationRepository;
+import se.sundsvall.checklist.integration.db.repository.SortorderRepository;
 
 @ExtendWith(MockitoExtension.class)
 class OrganizationServiceTest {
@@ -42,6 +44,9 @@ class OrganizationServiceTest {
 
 	@Mock
 	private ChecklistBuilder mockChecklistBuilder;
+
+	@Mock
+	private SortorderRepository mockSortorderRepository;
 
 	@InjectMocks
 	private OrganizationService organizationService;
@@ -174,11 +179,16 @@ class OrganizationServiceTest {
 	@Test
 	void deleteOrganization() {
 		final var entity = createOrganizationEntity();
+		final var sortOrderEntities = List.of(SortorderEntity.builder().build(), SortorderEntity.builder().build());
+
 		when(mockOrganizationRepository.findByIdAndMunicipalityId(entity.getId(), MUNICIPALITY_ID)).thenReturn(Optional.of(entity));
+		when(mockSortorderRepository.findAllByMunicipalityIdAndOrganizationNumber(MUNICIPALITY_ID, entity.getOrganizationNumber())).thenReturn(sortOrderEntities);
 
 		organizationService.deleteOrganization(MUNICIPALITY_ID, entity.getId());
 
 		verify(mockOrganizationRepository).findByIdAndMunicipalityId(entity.getId(), MUNICIPALITY_ID);
+		verify(mockSortorderRepository).findAllByMunicipalityIdAndOrganizationNumber(MUNICIPALITY_ID, entity.getOrganizationNumber());
+		verify(mockSortorderRepository).deleteAllInBatch(sortOrderEntities);
 		verify(mockOrganizationRepository).delete(entity);
 	}
 
@@ -210,6 +220,6 @@ class OrganizationServiceTest {
 
 	@AfterEach
 	void verifyNoMoreInteraction() {
-		verifyNoMoreInteractions(mockOrganizationRepository, mockChecklistBuilder);
+		verifyNoMoreInteractions(mockOrganizationRepository, mockChecklistBuilder, mockSortorderRepository);
 	}
 }

--- a/src/test/java/se/sundsvall/checklist/service/SortorderServiceTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/SortorderServiceTest.java
@@ -1,0 +1,56 @@
+package se.sundsvall.checklist.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+import static se.sundsvall.checklist.TestObjectFactory.generateSortorderRequest;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import se.sundsvall.checklist.integration.db.model.SortorderEntity;
+import se.sundsvall.checklist.integration.db.repository.SortorderRepository;
+
+@ExtendWith(MockitoExtension.class)
+class SortorderServiceTest {
+
+	private static final String MUNICIPALITY_ID = "municipalityId";
+	private static final int ORGANIZATION_NUMBER = 123456;
+
+	@Mock
+	private SortorderRepository sortorderRepositoryMock;
+
+	@InjectMocks
+	private SortorderService service;
+
+	@Captor
+	private ArgumentCaptor<List<SortorderEntity>> saveAllCaptor;
+
+	@Test
+	void saveSortorder() {
+		// Arrange
+		final var sortorderRequest = generateSortorderRequest();
+		final var sortorderEntities = List.of(SortorderEntity.builder().build(), SortorderEntity.builder().build());
+
+		when(sortorderRepositoryMock.findAllByMunicipalityIdAndOrganizationNumber(MUNICIPALITY_ID, ORGANIZATION_NUMBER)).thenReturn(sortorderEntities);
+
+		// Act
+		service.saveSortorder(MUNICIPALITY_ID, ORGANIZATION_NUMBER, sortorderRequest);
+
+		// Assert and verify
+		verify(sortorderRepositoryMock).findAllByMunicipalityIdAndOrganizationNumber(MUNICIPALITY_ID, ORGANIZATION_NUMBER);
+		verify(sortorderRepositoryMock).deleteAllInBatch(sortorderEntities);
+		verify(sortorderRepositoryMock).saveAll(saveAllCaptor.capture());
+		verifyNoMoreInteractions(sortorderRepositoryMock);
+
+		assertThat(saveAllCaptor.getValue()).hasSize(6);
+	}
+}

--- a/src/test/java/se/sundsvall/checklist/service/mapper/SortorderMapperTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/mapper/SortorderMapperTest.java
@@ -1,0 +1,92 @@
+package se.sundsvall.checklist.service.mapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static se.sundsvall.checklist.TestObjectFactory.generateSortorderRequest;
+import static se.sundsvall.checklist.integration.db.model.enums.ComponentType.PHASE;
+import static se.sundsvall.checklist.integration.db.model.enums.ComponentType.TASK;
+
+import org.junit.jupiter.api.Test;
+
+import se.sundsvall.checklist.api.model.SortorderRequest;
+
+class SortorderMapperTest {
+	private static final String MUNICIPALITY_ID = "municipalityId";
+	private static final int ORGANIZATION_NUMBER = 987;
+
+	@Test
+	void toSortorderEntities() {
+		// Arrange
+		final var request = generateSortorderRequest();
+
+		// Act
+		final var entities = SortorderMapper.toSortorderEntities(MUNICIPALITY_ID, ORGANIZATION_NUMBER, request);
+
+		// Assert
+		assertThat(entities).hasSize(6);
+
+		assertThat(entities.stream()
+			.filter(entity -> PHASE == entity.getComponentType())
+			.toList())
+			.satisfiesExactlyInAnyOrder(entity -> {
+				assertThat(entity.getComponentId()).isEqualTo(request.getPhaseOrder().getFirst().getId());
+				assertThat(entity.getPosition()).isEqualTo(request.getPhaseOrder().getFirst().getPosition());
+			}, entity -> {
+				assertThat(entity.getComponentId()).isEqualTo(request.getPhaseOrder().getLast().getId());
+				assertThat(entity.getPosition()).isEqualTo(request.getPhaseOrder().getLast().getPosition());
+			});
+
+		assertThat(entities.stream()
+			.filter(entity -> TASK == entity.getComponentType())
+			.toList())
+			.satisfiesExactlyInAnyOrder(entity -> {
+				assertThat(entity.getComponentId()).isEqualTo(request.getPhaseOrder().getFirst().getTaskOrder().getFirst().getId());
+				assertThat(entity.getPosition()).isEqualTo(request.getPhaseOrder().getFirst().getTaskOrder().getFirst().getPosition());
+			}, entity -> {
+				assertThat(entity.getComponentId()).isEqualTo(request.getPhaseOrder().getFirst().getTaskOrder().getLast().getId());
+				assertThat(entity.getPosition()).isEqualTo(request.getPhaseOrder().getFirst().getTaskOrder().getLast().getPosition());
+			}, entity -> {
+				assertThat(entity.getComponentId()).isEqualTo(request.getPhaseOrder().getLast().getTaskOrder().getFirst().getId());
+				assertThat(entity.getPosition()).isEqualTo(request.getPhaseOrder().getLast().getTaskOrder().getFirst().getPosition());
+			}, entity -> {
+				assertThat(entity.getComponentId()).isEqualTo(request.getPhaseOrder().getLast().getTaskOrder().getLast().getId());
+				assertThat(entity.getPosition()).isEqualTo(request.getPhaseOrder().getLast().getTaskOrder().getLast().getPosition());
+			});
+	}
+
+	@Test
+	void toSortorderEntitiesWhenNoTasksPresent() {
+		// Arrange
+		final var request = generateSortorderRequest();
+		request.getPhaseOrder().forEach(phase -> phase.setTaskOrder(null));
+
+		// Act
+		final var entities = SortorderMapper.toSortorderEntities(MUNICIPALITY_ID, ORGANIZATION_NUMBER, request);
+
+		// Assert
+		assertThat(entities).hasSize(2).satisfiesExactlyInAnyOrder(entity -> {
+			assertThat(entity.getComponentId()).isEqualTo(request.getPhaseOrder().getFirst().getId());
+			assertThat(entity.getPosition()).isEqualTo(request.getPhaseOrder().getFirst().getPosition());
+		}, entity -> {
+			assertThat(entity.getComponentId()).isEqualTo(request.getPhaseOrder().getLast().getId());
+			assertThat(entity.getPosition()).isEqualTo(request.getPhaseOrder().getLast().getPosition());
+		});
+	}
+
+	@Test
+	void toSortorderEntitiesWhenNoPhasesPresent() {
+		// Arrange
+		final var request = SortorderRequest.builder().build();
+
+		// Act
+		final var entities = SortorderMapper.toSortorderEntities(MUNICIPALITY_ID, ORGANIZATION_NUMBER, request);
+
+		// Assert
+		assertThat(entities).isEmpty();
+	}
+
+	@Test
+	void toSortorderEntitiesFromNull() {
+		assertThat(SortorderMapper.toSortorderEntities(null, null, null)).isNull();
+	}
+
+}

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -289,7 +289,6 @@ paths:
           items:
             type: integer
             format: int32
-        example: 5432
       responses:
         "500":
           description: Internal Server Error

--- a/src/test/resources/db/scripts/customSortorderIT-testdata.sql
+++ b/src/test/resources/db/scripts/customSortorderIT-testdata.sql
@@ -1,0 +1,26 @@
+INSERT INTO organization(municipality_id, organization_number, created, updated, organization_name, id)
+VALUES ('2281',  13, now(), now(), 'Sundsvalls kommun', 'cfcb03b1-7344-4352-9b72-7aebb1f235e1'),
+       ('2281', 578, now(), now(), 'Sub-avdelning 578', '047c78a2-aadc-40e5-8913-8623b1fecc35');
+
+INSERT INTO checklist(municipality_id, id, organization_id, name, VERSION, life_cycle, created, last_saved_by)
+VALUES ('2281', '15764278-50c8-4a19-af00-077bfc314fd2', 'cfcb03b1-7344-4352-9b72-7aebb1f235e1', 'Övergripande checklista som ärvs av alla enheter under Svall', 1, 'ACTIVE', '2019-01-01 00:00:00', 'someUser');
+
+INSERT INTO phase(municipality_id, id, name, body_text, time_to_complete, sort_order, created, last_saved_by)
+VALUES ('2281', '1455a5d4-1db8-4a25-a49f-92fdd0c60a14', 'Fas-1', 'Beskrivning fas-1', 'P1W', 1, '2019-01-01 00:00:00', 'someUser'),
+       ('2281', '2455a5d4-1db8-4a25-a49f-92fdd0c60a14', 'Fas-2', 'Beskrivning fas-2', 'P2W', 1, '2019-01-01 00:00:00', 'someUser');
+
+INSERT INTO task(id, heading, text, role_type, question_type, created, sort_order, last_saved_by, checklist_id, phase_id)
+VALUES ('aba82aca-f841-4257-baec-d745e3ab78bf', 'Uppgift-1', 'Beskrivning av 1', 'NEW_EMPLOYEE', 'YES_OR_NO', '2019-01-01 00:00:00', 1, 'someUser', '15764278-50c8-4a19-af00-077bfc314fd2', '1455a5d4-1db8-4a25-a49f-92fdd0c60a14'),
+       ('bba82aca-f841-4257-baec-d745e3ab78bf', 'Uppgift-2', 'Beskrivning av 2', 'NEW_EMPLOYEE', 'YES_OR_NO', '2019-01-01 00:00:00', 1, 'someUser', '15764278-50c8-4a19-af00-077bfc314fd2', '1455a5d4-1db8-4a25-a49f-92fdd0c60a14');
+
+INSERT INTO custom_sortorder (id, municipality_id, organization_number, component_type, component_id, position)
+VALUES -- organizational unit 13
+('01ca2228-c49e-4e36-91c6-8e3bcb733c14', '2281',  13, 'PHASE', '1455a5d4-1db8-4a25-a49f-92fdd0c60a14', 1),
+('02ca2228-c49e-4e36-91c6-8e3bcb733c14', '2281',  13, 'PHASE', '2455a5d4-1db8-4a25-a49f-92fdd0c60a14', 2),
+('03ca2228-c49e-4e36-91c6-8e3bcb733c14', '2281',  13, 'TASK', 'aba82aca-f841-4257-baec-d745e3ab78bf', 1),
+('04ca2228-c49e-4e36-91c6-8e3bcb733c14', '2281',  13, 'TASK', 'bba82aca-f841-4257-baec-d745e3ab78bf', 2),
+-- organizational unit 578
+('05ca2228-c49e-4e36-91c6-8e3bcb733c14', '2281', 578, 'PHASE', '1455a5d4-1db8-4a25-a49f-92fdd0c60a14', 1),
+('06ca2228-c49e-4e36-91c6-8e3bcb733c14', '2281', 578, 'PHASE', '2455a5d4-1db8-4a25-a49f-92fdd0c60a14', 2),
+('07ca2228-c49e-4e36-91c6-8e3bcb733c14', '2281', 578, 'TASK', 'aba82aca-f841-4257-baec-d745e3ab78bf', 1),
+('08ca2228-c49e-4e36-91c6-8e3bcb733c14', '2281', 578, 'TASK', 'bba82aca-f841-4257-baec-d745e3ab78bf', 2);


### PR DESCRIPTION
- Implemented service layer for adminstration of custom sort order
- Removed example value for organization filter due to interference when using swagger UI
- Extended task and phase services to also clean up custom sort table when removing a task or a phase
- Optimized delete methods for sort order table to use batch instead of single row deletion

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
