### PR TITLE
UF-14187: Changed access mode to enums not visible in requests

### DIFF
--- a/src/main/java/se/sundsvall/checklist/api/model/CustomTask.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/CustomTask.java
@@ -35,10 +35,10 @@ public class CustomTask {
 	@Schema(description = "The sort order for the task", accessMode = READ_ONLY)
 	private Integer sortOrder;
 
-	@Schema(description = "The role type of the task", accessMode = READ_ONLY)
+	@Schema(description = "The role type of the task")
 	private RoleType roleType;
 
-	@Schema(description = "The question type of the task", accessMode = READ_ONLY)
+	@Schema(description = "The question type of the task")
 	private QuestionType questionType;
 
 	@Schema(description = "The date and time the task was created", example = "2023-11-22T15:30:00+03:00", accessMode = READ_ONLY)

--- a/src/main/java/se/sundsvall/checklist/api/model/CustomTaskCreateRequest.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/CustomTaskCreateRequest.java
@@ -29,7 +29,7 @@ public class CustomTaskCreateRequest {
 	@Schema(description = "The body text of the task", example = "Detta är en beskrivning av ett uppdrag", accessMode = WRITE_ONLY)
 	private String text;
 
-	@Schema(description = "The question type of the task", accessMode = WRITE_ONLY)
+	@Schema(description = "The question type of the task")
 	@NotNull
 	private QuestionType questionType;
 

--- a/src/main/java/se/sundsvall/checklist/api/model/CustomTaskUpdateRequest.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/CustomTaskUpdateRequest.java
@@ -27,7 +27,7 @@ public class CustomTaskUpdateRequest {
 	@Schema(description = "The body text of the task", example = "Detta är en beskrivning av ett uppdrag", accessMode = WRITE_ONLY)
 	private String text;
 
-	@Schema(description = "The question type of the task", accessMode = WRITE_ONLY)
+	@Schema(description = "The question type of the task")
 	private QuestionType questionType;
 
 	@Schema(description = "The sort order for the task", accessMode = WRITE_ONLY)

--- a/src/main/java/se/sundsvall/checklist/api/model/EmployeeChecklistTask.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/EmployeeChecklistTask.java
@@ -36,10 +36,10 @@ public class EmployeeChecklistTask {
 	@Schema(description = "The sort order for the task", accessMode = READ_ONLY)
 	private Integer sortOrder;
 
-	@Schema(description = "The role type of the task", accessMode = READ_ONLY)
+	@Schema(description = "The role type of the task")
 	private RoleType roleType;
 
-	@Schema(description = "The question type of the task", accessMode = READ_ONLY)
+	@Schema(description = "The question type of the task")
 	private QuestionType questionType;
 
 	@Schema(description = "Tells if the task is only applies to the current checklist or not", accessMode = READ_ONLY)
@@ -48,7 +48,7 @@ public class EmployeeChecklistTask {
 	@Schema(description = "The task response text", example = "Jag har bjudit på fika", accessMode = READ_ONLY)
 	private String responseText;
 
-	@Schema(description = "The status of the task fulfilment", example = "TRUE", accessMode = READ_ONLY)
+	@Schema(description = "The status of the task fulfilment", example = "TRUE")
 	private FulfilmentStatus fulfilmentStatus;
 
 	@Schema(description = "The date and time the task was last updated", example = "2023-11-22T15:30:00+03:00", accessMode = READ_ONLY)

--- a/src/main/java/se/sundsvall/checklist/api/model/Phase.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/Phase.java
@@ -34,7 +34,7 @@ public class Phase {
 	@Schema(description = "The time to complete the phase", example = "P1M", accessMode = READ_ONLY)
 	private String timeToComplete;
 
-	@Schema(description = "The permission needed to administrate the phase", accessMode = READ_ONLY)
+	@Schema(description = "The permission needed to administrate the phase")
 	private Permission permission;
 
 	@Schema(description = "The sort order of the phase", example = "1", accessMode = READ_ONLY)

--- a/src/main/java/se/sundsvall/checklist/api/model/PhaseCreateRequest.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/PhaseCreateRequest.java
@@ -31,7 +31,7 @@ public class PhaseCreateRequest {
 	@ValidPeriod
 	private String timeToComplete;
 
-	@Schema(description = "The permission needed to administrate the phase", accessMode = WRITE_ONLY)
+	@Schema(description = "The permission needed to administrate the phase")
 	@NotNull
 	private Permission permission;
 

--- a/src/main/java/se/sundsvall/checklist/api/model/PhaseUpdateRequest.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/PhaseUpdateRequest.java
@@ -29,7 +29,7 @@ public class PhaseUpdateRequest {
 	@ValidPeriod(nullable = true)
 	private String timeToComplete;
 
-	@Schema(description = "The permission needed to administrate the phase", accessMode = WRITE_ONLY)
+	@Schema(description = "The permission needed to administrate the phase")
 	private Permission permission;
 
 	@Schema(description = "The sort order of the phase", example = "1", accessMode = WRITE_ONLY)

--- a/src/main/java/se/sundsvall/checklist/api/model/Task.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/Task.java
@@ -37,13 +37,13 @@ public class Task {
 	@Schema(description = "The sort order of the task", example = "1", accessMode = READ_ONLY)
 	private int sortOrder;
 
-	@Schema(description = "The role type eligable for the task", example = "EMPLOYEE", accessMode = READ_ONLY)
+	@Schema(description = "The role type eligable for the task")
 	private RoleType roleType;
 
-	@Schema(description = "The question type of the task", accessMode = READ_ONLY)
+	@Schema(description = "The question type of the task")
 	private QuestionType questionType;
 
-	@Schema(description = "The permission needed to administrate the task", accessMode = READ_ONLY)
+	@Schema(description = "The permission needed to administrate the task")
 	private Permission permission;
 
 	@Schema(description = "The date and time the task was created", example = "2023-11-22T15:30:00+03:00", accessMode = READ_ONLY)

--- a/src/main/java/se/sundsvall/checklist/api/model/TaskCreateRequest.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/TaskCreateRequest.java
@@ -35,15 +35,15 @@ public class TaskCreateRequest {
 	@NotNull
 	private Integer sortOrder;
 
-	@Schema(description = "The role type of the task", example = "EMPLOYEE", accessMode = WRITE_ONLY)
+	@Schema(description = "The role type of the task", example = "NEW_EMPLOYEE")
 	@NotNull
 	private RoleType roleType;
 
-	@Schema(description = "The permission needed to administrate the task", accessMode = WRITE_ONLY)
+	@Schema(description = "The permission needed to administrate the task")
 	@NotNull
 	private Permission permission;
 
-	@Schema(description = "The question type of the task", example = "YES_OR_NO", accessMode = WRITE_ONLY)
+	@Schema(description = "The question type of the task", example = "YES_OR_NO")
 	@NotNull
 	private QuestionType questionType;
 

--- a/src/main/java/se/sundsvall/checklist/api/model/TaskUpdateRequest.java
+++ b/src/main/java/se/sundsvall/checklist/api/model/TaskUpdateRequest.java
@@ -32,13 +32,13 @@ public class TaskUpdateRequest {
 	@Schema(description = "The sort order of the task", example = "1", accessMode = WRITE_ONLY)
 	private Integer sortOrder;
 
-	@Schema(description = "The role type of the task", example = "EMPLOYEE", accessMode = WRITE_ONLY)
+	@Schema(description = "The role type of the task")
 	private RoleType roleType;
 
-	@Schema(description = "The permission needed to administrate the task", accessMode = WRITE_ONLY)
+	@Schema(description = "The permission needed to administrate the task")
 	private Permission permission;
 
-	@Schema(description = "The question type of the task", accessMode = WRITE_ONLY)
+	@Schema(description = "The question type of the task")
 	private QuestionType questionType;
 
 	@Schema(description = "The id of the user updating the task", example = "joe01doe", accessMode = WRITE_ONLY)

--- a/src/test/resources/api/openapi.yaml
+++ b/src/test/resources/api/openapi.yaml
@@ -2751,7 +2751,6 @@ components:
     Permission:
       type: string
       description: The permission needed to administrate the phase
-      writeOnly: true
       enum:
         - SUPERADMIN
         - ADMIN
@@ -2861,7 +2860,6 @@ components:
     QuestionType:
       type: string
       description: The question type of the task
-      writeOnly: true
       enum:
         - YES_OR_NO
         - YES_OR_NO_WITH_TEXT
@@ -2921,7 +2919,6 @@ components:
     RoleType:
       type: string
       description: The role type of the task
-      readOnly: true
       enum:
         - NEW_EMPLOYEE
         - NEW_MANAGER


### PR DESCRIPTION
- Some of the enums used in both read and write scenarios have the access mode set to different values, but this creates a problem as the generated swagger will use the first available value for attribute (either READ_ONLY or WRITE_ONLY). If the value is set to READ_ONLY, the attribute will not show up in the model for the POST and PATCH resources using the enum reference. Fix is to remove access mode for enums used in both read and write scenarios.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
