### PR TITLE
UF-15472: Added scheduled job for cleansing old initiation info

### DIFF
--- a/src/main/java/se/sundsvall/checklist/integration/db/repository/InitiationRepository.java
+++ b/src/main/java/se/sundsvall/checklist/integration/db/repository/InitiationRepository.java
@@ -1,6 +1,7 @@
 package se.sundsvall.checklist.integration.db.repository;
 
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import java.time.OffsetDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,6 @@ import se.sundsvall.checklist.integration.db.model.InitiationInfoEntity;
 @CircuitBreaker(name = "initiationRepository")
 public interface InitiationRepository extends JpaRepository<InitiationInfoEntity, String> {
 	List<InitiationInfoEntity> findAllByMunicipalityId(String municipalityId);
+
+	void deleteAllByCreatedBefore(OffsetDateTime timestamp);
 }

--- a/src/main/java/se/sundsvall/checklist/service/scheduler/PurgeOldInitiationInfoScheduler.java
+++ b/src/main/java/se/sundsvall/checklist/service/scheduler/PurgeOldInitiationInfoScheduler.java
@@ -1,0 +1,54 @@
+package se.sundsvall.checklist.service.scheduler;
+
+import static java.time.format.DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+import static java.time.temporal.ChronoUnit.DAYS;
+
+import java.time.OffsetDateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import se.sundsvall.checklist.integration.db.repository.InitiationRepository;
+import se.sundsvall.dept44.scheduling.Dept44Scheduled;
+
+/**
+ * Scheduler for job to remove initiation information rows older than X days (configurable by properties) from the
+ * initiation_info table
+ */
+@Component
+public class PurgeOldInitiationInfoScheduler {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(PurgeOldInitiationInfoScheduler.class);
+	private static final String LOG_PURGE_STARTED = "Purging rows older than {} days from initiation_info table (i.e. rows with created date before {})";
+
+	private final InitiationRepository initiationRepository;
+	private final int maxLifetimeInDaysThreshold;
+
+	public PurgeOldInitiationInfoScheduler(InitiationRepository initiationRepository,
+		@Value("${checklist.purge-old-initiation-info.maximum-lifespan-in-days}") int maxLifetimeInDaysThreshold) {
+		this.initiationRepository = initiationRepository;
+		this.maxLifetimeInDaysThreshold = maxLifetimeInDaysThreshold;
+	}
+
+	/**
+	 * Removes initiation information rows with created date older than threshold from table.
+	 */
+	@Transactional
+	@Dept44Scheduled(
+		name = "${checklist.purge-old-initiation-info.name}",
+		cron = "${checklist.purge-old-initiation-info.cron}",
+		lockAtMostFor = "${checklist.purge-old-initiation-info.lockAtMostFor}",
+		maximumExecutionTime = "${checklist.purge-old-initiation-info.maximumExecutionTime}")
+	public void execute() {
+		final var oldestCreatedDate = OffsetDateTime.now().truncatedTo(DAYS).minusDays(maxLifetimeInDaysThreshold);
+		final var formattedDateTime = toReadableFormat(oldestCreatedDate);
+		LOGGER.info(LOG_PURGE_STARTED, maxLifetimeInDaysThreshold, formattedDateTime);
+
+		initiationRepository.deleteAllByCreatedBefore(oldestCreatedDate);
+	}
+
+	private String toReadableFormat(OffsetDateTime dateTime) {
+		return dateTime.format(ISO_LOCAL_DATE_TIME);
+	}
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -131,3 +131,9 @@ checklist:
     name: lockEmployeeChecklists
     lockAtMostFor: PT2M
     maximumExecutionTime: PT2M
+  purge-old-initiation-info:
+    cron: ${config.schedulers.purge-old-initiation-info.cron:-}
+    maximumLifespanInDays: ${config.schedulers.purge-old-initiation-info.maximum-lifespan-in-days:30}
+    name: purgeOldInitiationInfo
+    lockAtMostFor: PT2M
+    maximumExecutionTime: PT2M

--- a/src/test/java/se/sundsvall/checklist/service/scheduler/LockEmployeeChecklistsSchedulerShedlockTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/scheduler/LockEmployeeChecklistsSchedulerShedlockTest.java
@@ -1,0 +1,98 @@
+package se.sundsvall.checklist.service.scheduler;
+
+import static java.time.Clock.systemUTC;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import se.sundsvall.checklist.integration.db.repository.EmployeeChecklistRepository;
+
+@SpringBootTest(properties = {
+	"spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver",
+	"spring.datasource.url=jdbc:tc:mariadb:10.6.4:////",
+	"spring.flyway.enabled=true",
+	"config.jpa.hibernate.ddl-auto=validate",
+	"config.jpa.defer-datasource-initialization=false",
+	"config.schedulers.lock-employee-checklists.cron=* * * * * *", // Setup to execute every second
+	"server.shutdown=immediate",
+	"spring.lifecycle.timeout-per-shutdown-phase=0s"
+})
+@ActiveProfiles("junit")
+class LockEmployeeChecklistsSchedulerShedlockTest {
+
+	@TestConfiguration
+	public static class ShedlockTestConfiguration {
+		@Bean
+		@Primary
+		public EmployeeChecklistRepository createMock() {
+
+			final var mockBean = Mockito.mock(EmployeeChecklistRepository.class);
+
+			// Let mock hang
+			doAnswer(invocation -> {
+				mockCalledTime = LocalDateTime.now();
+				await().forever()
+					.until(() -> false);
+				return null;
+			}).when(mockBean).findAllByChecklistsMunicipalityIdAndExpirationDateIsBeforeAndLockedIsFalse(any(), any());
+
+			return mockBean;
+		}
+	}
+
+	@Autowired
+	private EmployeeChecklistRepository repository;
+
+	@Autowired
+	private NamedParameterJdbcTemplate jdbcTemplate;
+
+	private static LocalDateTime mockCalledTime;
+
+	@Test
+	void verifyShedLockForPurgeOfOldInitiationInfos() {
+		// Make sure scheduling occurs multiple times
+		await().until(() -> mockCalledTime != null && LocalDateTime.now().isAfter(mockCalledTime.plusSeconds(2)));
+
+		// Verify lock
+		await().atMost(5, SECONDS)
+			.untilAsserted(() -> assertThat(getLockedAt("lockEmployeeChecklists"))
+				.isCloseTo(LocalDateTime.now(systemUTC()), within(10, ChronoUnit.SECONDS)));
+
+		// Only one call should be made as long as transferFiles() is locked and mock is waiting for first call to finish
+		verify(repository).findAllByChecklistsMunicipalityIdAndExpirationDateIsBeforeAndLockedIsFalse(any(), any());
+		verifyNoMoreInteractions(repository);
+	}
+
+	private LocalDateTime getLockedAt(String name) {
+		return jdbcTemplate.query(
+			"SELECT locked_at FROM shedlock WHERE name = :name",
+			Map.of("name", name),
+			this::mapTimestamp);
+	}
+
+	private LocalDateTime mapTimestamp(final ResultSet rs) throws SQLException {
+		if (rs.next()) {
+			return rs.getTimestamp("locked_at").toLocalDateTime();
+		}
+		return null;
+	}
+}

--- a/src/test/java/se/sundsvall/checklist/service/scheduler/ManagerEmailSchedulerShedlockTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/scheduler/ManagerEmailSchedulerShedlockTest.java
@@ -1,0 +1,98 @@
+package se.sundsvall.checklist.service.scheduler;
+
+import static java.time.Clock.systemUTC;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import se.sundsvall.checklist.service.CommunicationService;
+
+@SpringBootTest(properties = {
+	"spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver",
+	"spring.datasource.url=jdbc:tc:mariadb:10.6.4:////",
+	"spring.flyway.enabled=true",
+	"config.jpa.hibernate.ddl-auto=validate",
+	"config.jpa.defer-datasource-initialization=false",
+	"config.schedulers.manager-email.cron=* * * * * *", // Setup to execute every second
+	"server.shutdown=immediate",
+	"spring.lifecycle.timeout-per-shutdown-phase=0s"
+})
+@ActiveProfiles("junit")
+class ManagerEmailSchedulerShedlockTest {
+
+	@TestConfiguration
+	public static class ShedlockTestConfiguration {
+		@Bean
+		@Primary
+		public CommunicationService createMock() {
+
+			final var mockBean = Mockito.mock(CommunicationService.class);
+
+			// Let mock hang
+			doAnswer(invocation -> {
+				mockCalledTime = LocalDateTime.now();
+				await().forever()
+					.until(() -> false);
+				return null;
+			}).when(mockBean).fetchManagersToSendMailTo(any());
+
+			return mockBean;
+		}
+	}
+
+	@Autowired
+	private CommunicationService service;
+
+	@Autowired
+	private NamedParameterJdbcTemplate jdbcTemplate;
+
+	private static LocalDateTime mockCalledTime;
+
+	@Test
+	void verifyShedLockForPurgeOfOldInitiationInfos() {
+		// Make sure scheduling occurs multiple times
+		await().until(() -> mockCalledTime != null && LocalDateTime.now().isAfter(mockCalledTime.plusSeconds(2)));
+
+		// Verify lock
+		await().atMost(5, SECONDS)
+			.untilAsserted(() -> assertThat(getLockedAt("sendEmailToManagers"))
+				.isCloseTo(LocalDateTime.now(systemUTC()), within(10, ChronoUnit.SECONDS)));
+
+		// Only one call should be made as long as transferFiles() is locked and mock is waiting for first call to finish
+		verify(service).fetchManagersToSendMailTo(any());
+		verifyNoMoreInteractions(service);
+	}
+
+	private LocalDateTime getLockedAt(String name) {
+		return jdbcTemplate.query(
+			"SELECT locked_at FROM shedlock WHERE name = :name",
+			Map.of("name", name),
+			this::mapTimestamp);
+	}
+
+	private LocalDateTime mapTimestamp(final ResultSet rs) throws SQLException {
+		if (rs.next()) {
+			return rs.getTimestamp("locked_at").toLocalDateTime();
+		}
+		return null;
+	}
+}

--- a/src/test/java/se/sundsvall/checklist/service/scheduler/PurgeOldInitiationInfoSchedulerShedlockTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/scheduler/PurgeOldInitiationInfoSchedulerShedlockTest.java
@@ -1,0 +1,98 @@
+package se.sundsvall.checklist.service.scheduler;
+
+import static java.time.Clock.systemUTC;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import se.sundsvall.checklist.integration.db.repository.InitiationRepository;
+
+@SpringBootTest(properties = {
+	"spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver",
+	"spring.datasource.url=jdbc:tc:mariadb:10.6.4:////",
+	"spring.flyway.enabled=true",
+	"config.jpa.hibernate.ddl-auto=validate",
+	"config.jpa.defer-datasource-initialization=false",
+	"checklist.purge-old-initiation-info.cron=* * * * * *", // Setup to execute every second
+	"server.shutdown=immediate",
+	"spring.lifecycle.timeout-per-shutdown-phase=0s"
+})
+@ActiveProfiles("junit")
+class PurgeOldInitiationInfoSchedulerShedlockTest {
+
+	@TestConfiguration
+	public static class ShedlockTestConfiguration {
+		@Bean
+		@Primary
+		public InitiationRepository createMock() {
+
+			final var mockBean = Mockito.mock(InitiationRepository.class);
+
+			// Let mock hang
+			doAnswer(invocation -> {
+				mockCalledTime = LocalDateTime.now();
+				await().forever()
+					.until(() -> false);
+				return null;
+			}).when(mockBean).deleteAllByCreatedBefore(any());
+
+			return mockBean;
+		}
+	}
+
+	@Autowired
+	private InitiationRepository repository;
+
+	@Autowired
+	private NamedParameterJdbcTemplate jdbcTemplate;
+
+	private static LocalDateTime mockCalledTime;
+
+	@Test
+	void verifyShedLockForPurgeOfOldInitiationInfos() {
+		// Make sure scheduling occurs multiple times
+		await().until(() -> mockCalledTime != null && LocalDateTime.now().isAfter(mockCalledTime.plusSeconds(2)));
+
+		// Verify lock
+		await().atMost(5, SECONDS)
+			.untilAsserted(() -> assertThat(getLockedAt("purgeOldInitiationInfo"))
+				.isCloseTo(LocalDateTime.now(systemUTC()), within(10, ChronoUnit.SECONDS)));
+
+		// Only one call should be made as long as transferFiles() is locked and mock is waiting for first call to finish
+		verify(repository).deleteAllByCreatedBefore(any());
+		verifyNoMoreInteractions(repository);
+	}
+
+	private LocalDateTime getLockedAt(String name) {
+		return jdbcTemplate.query(
+			"SELECT locked_at FROM shedlock WHERE name = :name",
+			Map.of("name", name),
+			this::mapTimestamp);
+	}
+
+	private LocalDateTime mapTimestamp(final ResultSet rs) throws SQLException {
+		if (rs.next()) {
+			return rs.getTimestamp("locked_at").toLocalDateTime();
+		}
+		return null;
+	}
+}

--- a/src/test/java/se/sundsvall/checklist/service/scheduler/PurgeOldInitiationInfoSchedulerTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/scheduler/PurgeOldInitiationInfoSchedulerTest.java
@@ -1,0 +1,39 @@
+package se.sundsvall.checklist.service.scheduler;
+
+import static java.time.temporal.ChronoUnit.DAYS;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import se.sundsvall.checklist.integration.db.repository.InitiationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class PurgeOldInitiationInfoSchedulerTest {
+
+	private static final int THRESHOLD_IN_DAYS = 123;
+
+	@Mock
+	private InitiationRepository initiationRepositoryMock;
+
+	private PurgeOldInitiationInfoScheduler scheduler;
+
+	@BeforeEach
+	void setup() {
+		scheduler = new PurgeOldInitiationInfoScheduler(initiationRepositoryMock, THRESHOLD_IN_DAYS);
+	}
+
+	@Test
+	void execute() {
+		// Act
+		scheduler.execute();
+
+		// Assert and verify
+		verify(initiationRepositoryMock).deleteAllByCreatedBefore(OffsetDateTime.now().truncatedTo(DAYS).minusDays(THRESHOLD_IN_DAYS));
+		verifyNoMoreInteractions(initiationRepositoryMock);
+	}
+}

--- a/src/test/java/se/sundsvall/checklist/service/scheduler/RetrieveNewEmployeesSchedulerShedlockTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/scheduler/RetrieveNewEmployeesSchedulerShedlockTest.java
@@ -1,0 +1,98 @@
+package se.sundsvall.checklist.service.scheduler;
+
+import static java.time.Clock.systemUTC;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.awaitility.Awaitility.await;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import se.sundsvall.checklist.service.EmployeeChecklistService;
+
+@SpringBootTest(properties = {
+	"spring.datasource.driver-class-name=org.testcontainers.jdbc.ContainerDatabaseDriver",
+	"spring.datasource.url=jdbc:tc:mariadb:10.6.4:////",
+	"spring.flyway.enabled=true",
+	"config.jpa.hibernate.ddl-auto=validate",
+	"config.jpa.defer-datasource-initialization=false",
+	"config.schedulers.new-employees.cron=* * * * * *", // Setup to execute every second
+	"server.shutdown=immediate",
+	"spring.lifecycle.timeout-per-shutdown-phase=0s"
+})
+@ActiveProfiles("junit")
+class RetrieveNewEmployeesSchedulerShedlockTest {
+
+	@TestConfiguration
+	public static class ShedlockTestConfiguration {
+		@Bean
+		@Primary
+		public EmployeeChecklistService createMock() {
+
+			final var mockBean = Mockito.mock(EmployeeChecklistService.class);
+
+			// Let mock hang
+			doAnswer(invocation -> {
+				mockCalledTime = LocalDateTime.now();
+				await().forever()
+					.until(() -> false);
+				return null;
+			}).when(mockBean).initiateEmployeeChecklists(any());
+
+			return mockBean;
+		}
+	}
+
+	@Autowired
+	private EmployeeChecklistService service;
+
+	@Autowired
+	private NamedParameterJdbcTemplate jdbcTemplate;
+
+	private static LocalDateTime mockCalledTime;
+
+	@Test
+	void verifyShedLockForPurgeOfOldInitiationInfos() {
+		// Make sure scheduling occurs multiple times
+		await().until(() -> mockCalledTime != null && LocalDateTime.now().isAfter(mockCalledTime.plusSeconds(2)));
+
+		// Verify lock
+		await().atMost(5, SECONDS)
+			.untilAsserted(() -> assertThat(getLockedAt("fetchNewEmployees"))
+				.isCloseTo(LocalDateTime.now(systemUTC()), within(10, ChronoUnit.SECONDS)));
+
+		// Only one call should be made as long as transferFiles() is locked and mock is waiting for first call to finish
+		verify(service).initiateEmployeeChecklists(any());
+		verifyNoMoreInteractions(service);
+	}
+
+	private LocalDateTime getLockedAt(String name) {
+		return jdbcTemplate.query(
+			"SELECT locked_at FROM shedlock WHERE name = :name",
+			Map.of("name", name),
+			this::mapTimestamp);
+	}
+
+	private LocalDateTime mapTimestamp(final ResultSet rs) throws SQLException {
+		if (rs.next()) {
+			return rs.getTimestamp("locked_at").toLocalDateTime();
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
- Added scheduled job with configurable threshold setting for cleansing old initiation info from database
- Added missing shedlock tests to schedulers in service

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
