### PR TITLE
HYDRAN-114: Added transactional annotation to update manager job

### DIFF
--- a/src/main/java/se/sundsvall/checklist/service/EmployeeChecklistService.java
+++ b/src/main/java/se/sundsvall/checklist/service/EmployeeChecklistService.java
@@ -444,6 +444,9 @@ public class EmployeeChecklistService {
 		Detail detail = null;
 
 		try {
+			if (isNull(remoteEmployee.getMainEmployment())) {
+				throw Problem.valueOf(NOT_FOUND, "No main employement was found");
+			}
 			if (notEqual(remoteEmployee.getMainEmployment().getManager().getPersonId(), localEmployee.getManager().getPersonId())) {
 				// First calculate information for response as local entity will be modified in next step
 				detail = toDetail(OK, createUpdateManagerDetailString(localEmployee, remoteEmployee));

--- a/src/main/java/se/sundsvall/checklist/service/scheduler/UpdateEmployeeManagerScheduler.java
+++ b/src/main/java/se/sundsvall/checklist/service/scheduler/UpdateEmployeeManagerScheduler.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 import se.sundsvall.checklist.api.model.EmployeeChecklistResponse;
@@ -33,6 +34,7 @@ public class UpdateEmployeeManagerScheduler {
 		this.properties = properties;
 	}
 
+	@Transactional
 	@Dept44Scheduled(
 		name = "${checklist.update-manager.name}",
 		cron = "${checklist.update-manager.cron}",

--- a/src/test/java/se/sundsvall/checklist/service/scheduler/LockEmployeeChecklistsSchedulerTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/scheduler/LockEmployeeChecklistsSchedulerTest.java
@@ -17,6 +17,7 @@ import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 import org.zalando.problem.Status;
 import org.zalando.problem.ThrowableProblem;
 import se.sundsvall.checklist.integration.db.model.EmployeeChecklistEntity;
@@ -36,6 +37,11 @@ class LockEmployeeChecklistsSchedulerTest {
 
 	@Captor
 	private ArgumentCaptor<EmployeeChecklistEntity> entityCaptor;
+
+	@Test
+	void verifyTransactionalAnnotation() throws NoSuchMethodException {
+		assertThat(LockEmployeeChecklistsScheduler.class.getMethod("execute").getAnnotation(Transactional.class)).isNotNull();
+	}
 
 	@Test
 	void executeWhenNoLockableEmployeeChecklistsExists() {

--- a/src/test/java/se/sundsvall/checklist/service/scheduler/PurgeOldInitiationInfoSchedulerTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/scheduler/PurgeOldInitiationInfoSchedulerTest.java
@@ -1,6 +1,7 @@
 package se.sundsvall.checklist.service.scheduler;
 
 import static java.time.temporal.ChronoUnit.DAYS;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 import se.sundsvall.checklist.integration.db.repository.InitiationRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,6 +27,11 @@ class PurgeOldInitiationInfoSchedulerTest {
 	@BeforeEach
 	void setup() {
 		scheduler = new PurgeOldInitiationInfoScheduler(initiationRepositoryMock, THRESHOLD_IN_DAYS);
+	}
+
+	@Test
+	void verifyTransactionalAnnotation() throws NoSuchMethodException {
+		assertThat(PurgeOldInitiationInfoScheduler.class.getMethod("execute").getAnnotation(Transactional.class)).isNotNull();
 	}
 
 	@Test

--- a/src/test/java/se/sundsvall/checklist/service/scheduler/UpdateEmployeeManagerSchedulerTest.java
+++ b/src/test/java/se/sundsvall/checklist/service/scheduler/UpdateEmployeeManagerSchedulerTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.annotation.Transactional;
 import org.zalando.problem.Problem;
 import org.zalando.problem.Status;
 import org.zalando.problem.ThrowableProblem;
@@ -31,6 +32,11 @@ class UpdateEmployeeManagerSchedulerTest {
 
 	@InjectMocks
 	private UpdateEmployeeManagerScheduler scheduler;
+
+	@Test
+	void verifyTransactionalAnnotation() throws NoSuchMethodException {
+		assertThat(UpdateEmployeeManagerScheduler.class.getMethod("execute").getAnnotation(Transactional.class)).isNotNull();
+	}
 
 	@Test
 	void execute() {


### PR DESCRIPTION
- Added transactional annotation to update manager job
- Added check that main employment is present, or else throws exception (instead of throwing npe when accessing it later)
- Extended tests to verify that annotation is present in jobs that requires a transaction

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
