### PR TITLE
Fix bugs found in code review

### DIFF
--- a/src/main/java/se/sundsvall/checklist/configuration/CacheConfiguration.java
+++ b/src/main/java/se/sundsvall/checklist/configuration/CacheConfiguration.java
@@ -22,7 +22,7 @@ public class CacheConfiguration {
 	@Value("${cache.employee.expire-after-write:PT12H}")
 	private Duration employeeExpireAfterWriteDuration;
 
-	@Value("${cache.mdviewer.expire-after-write:PT12H}")
+	@Value("${cache.company.expire-after-write:PT12H}")
 	private Duration companyExpireAfterWriteDuration;
 
 	@Bean

--- a/src/main/java/se/sundsvall/checklist/integration/employee/EmployeeMapper.java
+++ b/src/main/java/se/sundsvall/checklist/integration/employee/EmployeeMapper.java
@@ -174,7 +174,7 @@ public class EmployeeMapper {
 				.withGivenname(m.getGivenname())
 				.withLastname(m.getLastname())
 				.withLoginname(m.getLoginname())
-				.withPersonId(m.getPersonId().toString())
+				.withPersonId(ofNullable(m.getPersonId()).map(UUID::toString).orElse(null))
 				.build())
 			.orElse(null);
 	}

--- a/src/main/java/se/sundsvall/checklist/integration/eventlog/EventlogIntegration.java
+++ b/src/main/java/se/sundsvall/checklist/integration/eventlog/EventlogIntegration.java
@@ -43,7 +43,7 @@ public class EventlogIntegration {
 
 		try {
 			LOG.info("Fetching events for checklist: {}", sanitizedLogKey);
-			final var events = eventlogClient.getEvents(sanitizedMunicipalityId, sanitizedLogKey, pageable);
+			final var events = eventlogClient.getEvents(municipalityId, logKey, pageable);
 			LOG.info("Successfully fetched events for checklist: {}", sanitizedLogKey);
 			return events;
 		} catch (final Exception e) {

--- a/src/main/java/se/sundsvall/checklist/integration/eventlog/EventlogIntegration.java
+++ b/src/main/java/se/sundsvall/checklist/integration/eventlog/EventlogIntegration.java
@@ -38,7 +38,6 @@ public class EventlogIntegration {
 	}
 
 	public PageEvent getEvents(final String municipalityId, final String logKey, final Pageable pageable) {
-		final var sanitizedMunicipalityId = sanitizeAndCompress(municipalityId);
 		final var sanitizedLogKey = sanitizeAndCompress(logKey);
 
 		try {

--- a/src/main/java/se/sundsvall/checklist/service/OrganizationTree.java
+++ b/src/main/java/se/sundsvall/checklist/service/OrganizationTree.java
@@ -54,15 +54,12 @@ public class OrganizationTree {
 
 		for (final String line : split) {
 			final var split1 = line.split("\\|");
-			final var level = split1[0];
-			final var orgId = split1[1];
-			final var orgName = split1[2];
 
-			if (isCreatable(level)) {
+			if (split1.length >= 3 && isCreatable(split1[0])) {
 				organizationTree.addOrg(OrganizationTree.OrganizationLine.builder()
-					.withLevel(Integer.parseInt(level))
-					.withOrgId(orgId)
-					.withOrgName(orgName)
+					.withLevel(Integer.parseInt(split1[0]))
+					.withOrgId(split1[1])
+					.withOrgName(split1[2])
 					.build());
 			}
 		}

--- a/src/main/java/se/sundsvall/checklist/service/SortorderService.java
+++ b/src/main/java/se/sundsvall/checklist/service/SortorderService.java
@@ -160,10 +160,13 @@ public class SortorderService {
 	}
 
 	private Organization findOrganization(final String municipalityId, final Iterator<Organization> companyIterator, final Integer organizationNumber) {
+		if (!companyIterator.hasNext()) {
+			return null;
+		}
 		return companyIntegration.getOrganizationsForCompany(municipalityId, companyIterator.next().getCompanyId()).stream()
 			.filter(org -> org.getOrgId().equals(organizationNumber))
 			.findAny()
-			.orElse(companyIterator.hasNext() ? findOrganization(municipalityId, companyIterator, organizationNumber) : null);
+			.orElseGet(() -> findOrganization(municipalityId, companyIterator, organizationNumber));
 	}
 
 	private List<SortorderEntity> aggregateCustomSorts(final String municipalityId, final Organization organization) {

--- a/src/main/java/se/sundsvall/checklist/service/scheduler/ChecklistProperties.java
+++ b/src/main/java/se/sundsvall/checklist/service/scheduler/ChecklistProperties.java
@@ -4,5 +4,5 @@ import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("checklist")
-record ChecklistProperties(List<String> managedMunicipalityIds) {
+public record ChecklistProperties(List<String> managedMunicipalityIds) {
 }


### PR DESCRIPTION
- CacheConfiguration: read the cache.company.* property key (was the stale cache.mdviewer.*), so the company cache uses the configured 24h TTL instead of silently falling back to the 12h default
- SortorderService: use orElseGet so findOrganization stops issuing redundant HTTP calls after a match is found, and guard against an empty company iterator
- OrganizationTree: skip malformed org-string lines with fewer than three segments instead of throwing ArrayIndexOutOfBoundsException
- EmployeeMapper: null-guard manager personId to avoid NPE
- EventlogIntegration: pass raw municipalityId/logKey to the client instead of the log-sanitized values
- ChecklistProperties: make the record public to match its visibility

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have updated the documentation accordingly (if applicable).
- [ ] I have added/updated tests to cover my changes (if applicable).
